### PR TITLE
Add read list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,17 @@ name = "hessian_rs"
 version = "0.0.1"
 dependencies = [
  "byteorder",
+ "indexmap",
  "ordered-float",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ license = "GPL-3.0-or-later"
 [dependencies]
 ordered-float = "1.0"
 byteorder = "1.3.4"
+indexmap = "1.4.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use std::result;
 #[derive(Clone, PartialEq, Debug)]
 pub enum ErrorKind {
     UnknownType,
+    MisMatchType,
+    OutofTypeRefRange(usize),
 }
 
 #[derive(Debug)]

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -72,3 +72,15 @@ fn test_string_roundtrip() {
     roundtrip_test(String("abcdefghij".repeat(120)));
     roundtrip_test(String("abcdefghij".repeat(1000)));
 }
+
+#[test]
+fn test_list_roundtrip() {
+    roundtrip_test(List(vec![Int(1), Int(2)]));
+    roundtrip_test(List(vec![
+        String("".to_string()),
+        String("abc".to_string()),
+        String("中文".to_string()),
+    ]));
+    roundtrip_test(List(vec![Int(1); 13]));
+    roundtrip_test(List(vec![String("test".to_string()); 1000]));
+}


### PR DESCRIPTION
本次提交只是实现了list的基本编解码，由于list和map是复杂类型，根据hessian规范是需要添加引用的。
目前对于引用值和复杂类型这一块我并没有什么好的想法来处理，包括Value::Ref是存弱指针还是直接存ref_id，目前都没有清晰的想法。
对于解出的引用值，初步想法是deserializer中的引用表中存裸指针(deserializer的生命周期应当短于Value), 但是这会有unsafe的行为。

还有一个类型名的处理(在rust中似乎并没有什么用)，目前参考了hessian-go，对于读出的类名不进行处理。